### PR TITLE
Replace deprecated setExpectedException with expectException

### DIFF
--- a/tests/Module/UtilTest.php
+++ b/tests/Module/UtilTest.php
@@ -66,7 +66,7 @@ class UtilTest extends \PHPUnit_Framework_TestCase
      */
     public function testFromCsvFailsWithIncorrectData($csvString)
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
         $this->util->fromCsv($csvString);
     }
     

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -14,7 +14,7 @@ class ReportTest extends \PHPUnit_Framework_TestCase
         $step = new Step("Test");
         $step->setSuccess();
 
-        $this->setExpectedException(\LogicException::class);
+        $this->expectException(\LogicException::class);
         $step->setFailed(new AssertionFailedError("Test error"));
     }
 
@@ -25,7 +25,7 @@ class ReportTest extends \PHPUnit_Framework_TestCase
 
         $child = new Step("Child");
 
-        $this->setExpectedException(\LogicException::class);
+        $this->expectException(\LogicException::class);
         $step->addChild($child);
     }
 

--- a/tests/ScannerTest.php
+++ b/tests/ScannerTest.php
@@ -179,13 +179,13 @@ class ScannerTest extends \PHPUnit_Framework_TestCase
             [$range2, 'y']
         ];
 
-        $this->setExpectedException(TextException::class);
+        $this->expectException(TextException::class);
         $text->generateOutput($replace);
     }
 
     public function testCannotGenerateOutputWithInvalidRange()
     {
-        $this->setExpectedException(TextException::class);
+        $this->expectException(TextException::class);
 
         $text = TokenArray::fromTokens(array('<?php'));
         $range1 = Range::createIncluding($text, 0, 100);


### PR DESCRIPTION
Метод setExpectedException отмечен как [deprecated](https://github.com/sebastianbergmann/phpunit/blob/566b1efc147ba08de282475dc6765edfd208c5c7/src/Framework/TestCase.php#L553) начиная с PHPUnit 5.2
Его нет в PHPUnit 6.