### PR TITLE
Added document root

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ php cli/run-test.php cli/run-test/scenario.php cli/run-test/program1.php
 У приложения имеется веб-интерфейс. Чтобы его увидеть, необходимо запустить [встроенный в PHP веб-сервер](http://php.net/manual/ru/features.commandline.webserver.php) командой: 
 
 ```
-php -S 127.0.0.1:9001 public/index.php
+php -S 127.0.0.1:9001 -t public public/index.php
 ```
 
 После этого можно будет открыть в браузере страницу http://127.0.0.1:9001/ и увидеть список задач. 


### PR DESCRIPTION
В README предлагается использовать команду `php -S 127.0.0.1:9001 public/index.php` для запуска веб-интерфейса, однако в этом случае стили подгружаться не будут, так как корневая папка веб сервера совпадает с корневой папкой проекта. Стили [подключаются](https://github.com/codedokode/task-checker/blob/master/templates/layout.html.twig#L5) с расчётом на то, что корневая папка - public